### PR TITLE
Add Boss compatibility for Delphi

### DIFF
--- a/boss-lock.json
+++ b/boss-lock.json
@@ -1,0 +1,5 @@
+{
+	"hash": "d41d8cd98f00b204e9800998ecf8427e",
+	"updated": "2025-02-03T20:50:24.6725896-03:00",
+	"installedModules": {}
+}

--- a/boss.json
+++ b/boss.json
@@ -1,0 +1,9 @@
+{
+	"name": "TGPuttyLib",
+	"description": "A shared library / DLL with Delphi and C++ bindings based on PuTTY, for Windows, macOS, and Linux.",
+	"version": "1.0.0",
+	"homepage": "https://www.syncovery.com/tgputtylib/",
+	"mainsrc": ".",
+	"projects": [],
+	"dependencies": {}
+}


### PR DESCRIPTION
This commit adds compatibility with the Boss package manager for Delphi by including the boss.json and boss-lock.json configuration files. These files will help in managing dependencies more efficiently.